### PR TITLE
Added checks for Objects like Decimal

### DIFF
--- a/var_dump/_var_dump.py
+++ b/var_dump/_var_dump.py
@@ -49,9 +49,12 @@ def display(o, space, num, key, typ, proret):
 			l.append(o)
 
 	elif isinstance(o, object):
-		st += "object(%s) (%d)"
+		st += "object(%s) (%s)"
 		l.append(o.__class__.__name__)
-		l.append(len(o.__dict__))
+		try:
+			l.append(str(len(o.__dict__)))
+		except AttributeError:
+			l.append(str(o))
 
 	if proret:
 		print(st % tuple(l))
@@ -70,8 +73,11 @@ def dump(o, space, num, key, typ, proret):
 		if type(o) in (tuple, list, dict):
 			typ = type(o)  # type of the container of str, int, long, float etc
 		elif isinstance(o, object):
-			o = o.__dict__
-			typ = object
+			try:
+				o = o.__dict__
+				typ = object
+			except AttributeError:
+				return
 		for i in o:
 			space += TAB_SIZE
 			if type(o) is dict:


### PR DESCRIPTION
Certain objects can not be iterated and attempting to do so crashes the script. Instead I put try/except blocks around these objects so that they can instead be turned into strings and simply displayed as is instead of iterated.

This is a very cool module, it has helped me so much as I've been learning Python. I really appreciate that you made this and put it out there and I only hope that you except my commit so I can give back and help others as well.

Thanks,

Chris