### PR TITLE
add value to the name...

### DIFF
--- a/var_dump/_var_dump.py
+++ b/var_dump/_var_dump.py
@@ -58,7 +58,20 @@ def display(o, space, num, key, typ, proret):
 
     elif isinstance(o, object):
         st += "object(%s) (%s)"
-        l.append(o.__class__.__name__)
+        nameValueString = None
+        try:
+            tmp = o.value
+            if tmp is not None:
+                tmp = str(tmp)
+                nameValueString = tmp
+        except:
+            # o.value does not exist or can not be converted to string
+            pass
+        if nameValueString is None or nameValueString == "":
+            nameValueString = o.__class__.__name__
+        else:
+            nameValueString = o.__class__.__name__ + "(" + nameValueString + ")"
+        l.append(nameValueString)
         try:
             l.append(len(o.__dict__))
         except AttributeError:


### PR DESCRIPTION
lots of things possibly wrong with this
- i don't know if this works on python2.7
- i don't know if this is a good fix
- i don't know what this might break
- i did not run it through any testsuite (does a testsuite exist? if it does, i am unaware)

however, previously this
```
import ctypes
import ctypes.wintypes
from var_dump import var_dump

foo = ctypes.wintypes.ULARGE_INTEGER(123)
print(foo)
var_dump(foo)
```
would produce
```
c_ulonglong(123)
#0 object(c_ulonglong) (0)
```
and print() actually did a better job than var_dump() here,
but now it produce:
```
c_ulonglong(123)
#0 object(c_ulonglong(123)) (0)
```
doing at least as good a job as print :)