### PR TITLE
attempt to use str() to get object name

### DIFF
--- a/var_dump/_var_dump.py
+++ b/var_dump/_var_dump.py
@@ -58,7 +58,10 @@ def display(o, space, num, key, typ, proret):
 
     elif isinstance(o, object):
         st += "object(%s) (%s)"
-        l.append(o.__class__.__name__)
+        try:
+            l.append(str(o))
+        except:
+            l.append(o.__class__.__name__)
         try:
             l.append(len(o.__dict__))
         except AttributeError:


### PR DESCRIPTION
lots of things possibly wrong with this
- i don't know if this works on python2.7
- i don't know if this is a good fix
- i don't know what this might break
- i did not run it through any testsuite (does a testsuite exist? if it does, i am unaware)

however, previously this
```
import ctypes
import ctypes.wintypes
from var_dump import var_dump

foo = ctypes.wintypes.ULARGE_INTEGER(123)
print(foo)
var_dump(foo)
```
would produce
```
c_ulonglong(123)
#0 object(c_ulonglong) (0)
```
and print() actually did a better job than var_dump() here,
but now it produce:
```
c_ulonglong(123)
#0 object(c_ulonglong(123)) (0)
```
doing at least as good a job as print :)
this also fixes `ctypes.wintypes.HANDLE` which has the same problem as `ctypes.wintypes.ULARGE_INTEGER`
this is an alternative to #16  and fixes #15