### PR TITLE
fix TabErrors in sample code

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,32 +47,39 @@ you can pass more than one argument:
 
 #### Example #3: ####
     
-	from var_dump import var_dump
+```python
+from var_dump import var_dump
 
-	class Base(object):
-	
-	    def __init__(self):
-	        self.baseProp = (33, 44)
-			self.fl = 44.33
 
-	class Bar(object):
-	
-	    def __init__(self):
-	        self.barProp = "I'm from Bar class"
-			self.boo = True
-	
-	
-	class Foo(Base):
-	
-	    def __init__(self):
-	        super(Foo, self).__init__()
-	        self.someList = ['foo', 'goo']
-	        self.someTuple = (33, (23, 44), 55)
-	        self.anOb = Bar()
-			self.no = None
-	
-	foo = Foo()
-	var_dump(foo)
+class Base(object):
+
+    def __init__(self):
+        self.baseProp = (33, 44)
+        self.fl = 44.33
+
+
+class Bar(object):
+
+    def __init__(self):
+        self.barProp = "I'm from Bar class"
+        self.boo = True
+
+
+class Foo(Base):
+
+    def __init__(self):
+        super(Foo, self).__init__()
+        self.someList = ['foo', 'goo']
+        self.someTuple = (33, (23, 44), 55)
+        self.anOb = Bar()
+        self.no = None
+
+
+foo = Foo()
+# var_dump(foo)
+print(foo)
+
+```
 
 #### Output ####
 	#0 object(Foo) (6)


### PR DESCRIPTION
the sample code contained 3x TabError's where spaces were mixed with tabs causing errors like

File "C:\cygwin64\home\hans\tibia\pybot\test.py", line 25
    self.no = None
TabError: inconsistent use of tabs and spaces in indentation