### PR TITLE
fix \x9F crash-on-windows with hex encoding

### DIFF
--- a/var_dump/_var_dump.py
+++ b/var_dump/_var_dump.py
@@ -65,8 +65,21 @@ def display(o, space, num, key, typ, proret):
             l.append(str(o))
 
     if proret:
-        print(st % tuple(l))
-
+        try:
+            print(st % tuple(l))
+        except UnicodeEncodeError as err:
+            # may happen on Windows when stdout is piped to a file
+            # for unknown reasons... ref https://github.com/sha256/python-var-dump/issues/19
+            # lets replace all non-ascii characters with \xHEX
+            lc = list(l)
+            fixedstr = ''
+            for i in range(len(lc[3])):
+                try:
+                    fixedstr += lc[3][i].encode('ascii', 'strict').decode('ascii', 'strict')
+                except UnicodeEncodeError:
+                    fixedstr += "\\x"+ (hex(ord(lc[3][i]))[2:].zfill(2))
+            lc[3] = fixedstr
+            print(st % tuple(lc))
     return st % tuple(l)
 
 


### PR DESCRIPTION
previously var_dump('\x9F'); may cause a crash on windows cmd.exe , fix that by hex-encoding instead of crashing. for more info, see https://github.com/sha256/python-var-dump/issues/19