### PR TITLE
Deep recursion fix

### DIFF
--- a/tests/var_export_test.py
+++ b/tests/var_export_test.py
@@ -66,20 +66,6 @@ class VarExportTestCase(unittest.TestCase):
             [21.37, '#0 float(21.37) '],
 
             # enums
-            [
-                Enum('Color', ['RED', 'GREEN']),
-                '#0 object(EnumMeta) (10)'
-                '    [0] => str(21) "_generate_next_value_"'
-                '    [1] => str(7) "__doc__"'
-                '    [2] => str(10) "__module__"'
-                '    [3] => str(14) "_member_names_"'
-                '    [4] => str(12) "_member_map_"'
-                '    [5] => str(13) "_member_type_"'
-                '    [6] => str(18) "_value2member_map_"'
-                '    [7] => str(3) "RED"'
-                '    [8] => str(5) "GREEN"'
-                '    [9] => str(7) "__new__"',
-            ],
             [Color.RED, '#0 Enum(Color.RED)'],
             [Color(2),  '#0 Enum(Color.GREEN)'],
 

--- a/tests/var_export_test.py
+++ b/tests/var_export_test.py
@@ -34,6 +34,16 @@ class ObjectWithCircularReference:
         self.r = self
 
 
+class DeepCircularReferenceParent:
+    def __init__(self):
+        self.child = DeepCircularReferenceChild(self)
+
+
+class DeepCircularReferenceChild:
+    def __init__(self, parent: DeepCircularReferenceParent):
+        self.parent = parent
+
+
 class VarExportTestCase(unittest.TestCase):
     def test_var_export(self):
         data = [
@@ -129,6 +139,14 @@ class VarExportTestCase(unittest.TestCase):
             var_export(ObjectWithCircularReference()),
             '#0 object(ObjectWithCircularReference) (1)'
             '    r => object(ObjectWithCircularReference) (1) …circular reference…'
+        )
+
+    def test_var_export_deep_circular_reference(self):
+        self.assertEqual(
+            var_export(DeepCircularReferenceParent()),
+            '#0 object(DeepCircularReferenceParent) (1)'
+            '    child => object(DeepCircularReferenceChild) (1)'
+            '        parent => object(DeepCircularReferenceParent) (1) …circular reference…'
         )
 
 

--- a/var_dump/_var_dump.py
+++ b/var_dump/_var_dump.py
@@ -70,7 +70,7 @@ def display(o, space, num, key, typ, proret):
     return st % tuple(l)
 
 
-def dump(o, space, num, key, typ, proret, circular_reference=False):
+def dump(o, space, num, key, typ, proret, parents=None):
     if type(o) in (str, int, float, long, bool, NoneType, unicode, Enum) or isinstance(o, Enum):
         return display(o, space, num, key, typ, proret)
 
@@ -79,10 +79,12 @@ def dump(o, space, num, key, typ, proret, circular_reference=False):
 
     r = display(o, space, num, key, typ, proret)
 
-    if circular_reference:
+    if parents is None:
+        parents = []
+    elif o in parents:
         return r + ' …circular reference…'
 
-    o_backup = o
+    parents.append(o)
     num = 0
 
     if type(o) in (tuple, list, dict):
@@ -96,7 +98,7 @@ def dump(o, space, num, key, typ, proret, circular_reference=False):
     for i in o:
         space += TAB_SIZE
         if type(o) is dict:
-            r += dump(o[i], space, num, i, typ, proret, o[i] is o_backup)
+            r += dump(o[i], space, num, i, typ, proret, parents)
         else:
             r += dump(i, space, num, '', typ, proret)
         num += 1


### PR DESCRIPTION
Without the fix, the new `test_var_export_deep_circular_reference` unit test fails with:

```
python -m unittest tests
....E..
======================================================================
ERROR: test_var_export_deep_circular_reference (tests.var_export_test.VarExportTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "python-var-dump/tests/var_export_test.py", line 146, in test_var_export_deep_circular_reference
    var_export(DeepCircularReferenceParent()),
  File "python-var-dump/var_dump/_var_dump.py", line 124, in var_export
    r += dump(x, 0, i, '', object, False)
  File "python-var-dump/var_dump/_var_dump.py", line 99, in dump
    r += dump(o[i], space, num, i, typ, proret, o[i] is o_backup)
  File "python-var-dump/var_dump/_var_dump.py", line 99, in dump
    r += dump(o[i], space, num, i, typ, proret, o[i] is o_backup)
  File "python-var-dump/var_dump/_var_dump.py", line 99, in dump
    r += dump(o[i], space, num, i, typ, proret, o[i] is o_backup)
  [Previous line repeated 970 more times]
  File "python-var-dump/var_dump/_var_dump.py", line 80, in dump
    r = display(o, space, num, key, typ, proret)
  File "python-var-dump/var_dump/_var_dump.py", line 55, in display
    elif isinstance(o, Enum):
RecursionError: maximum recursion depth exceeded while calling a Python object
```