### PR TITLE
bugfix: nested objects: comparing the current object to its parents

### DIFF
--- a/tests/var_export_test.py
+++ b/tests/var_export_test.py
@@ -44,6 +44,14 @@ class DeepCircularReferenceChild:
         self.parent = parent
 
 
+class ParentObjectThatIsEqualToOthers:
+    def __init__(self):
+        self.foo = Foo()
+
+    def __eq__(self, other):
+        return True
+
+
 class VarExportTestCase(unittest.TestCase):
     def test_var_export(self):
         data = [
@@ -125,6 +133,16 @@ class VarExportTestCase(unittest.TestCase):
             var_export(ObjectWithCircularReference()),
             '#0 object(ObjectWithCircularReference) (1)'
             '    r => object(ObjectWithCircularReference) (1) …circular reference…'
+        )
+
+    def test_var_export_compares_parents_by_reference_not_value(self):
+        self.assertEqual(
+            var_export(ParentObjectThatIsEqualToOthers()),
+            '#0 object(ParentObjectThatIsEqualToOthers) (1)'
+            '    foo => object(Foo) (3)'
+            '        x => int(5) '
+            '        y => str(3) "abc"'
+            '        z => bool(True) '
         )
 
     def test_var_export_deep_circular_reference(self):

--- a/var_dump/_var_dump.py
+++ b/var_dump/_var_dump.py
@@ -81,7 +81,7 @@ def dump(o, space, num, key, typ, proret, parents=None):
 
     if parents is None:
         parents = []
-    elif o in parents:
+    elif any(o is parent for parent in parents):
         return r + ' …circular reference…'
 
     parents.append(o)


### PR DESCRIPTION
bugfix: nested objects: comparing the current object to its parents **by references**, not **by values**

I actually noticed the problem while testing `var_dump` in a "real application", on objects with (buggy) custom `__eq__` implementations: https://github.com/platformio/platformio-core/pull/4625

Without the fix, the new `test_var_export_compares_parents_by_reference_not_value` would give:

```
#0 object(ObjectThatIsEqualToOthers) (1)    foo => object(Foo) (3) …circular reference…
```

while a normal `Foo` representation should be expected:

```
#0 object(ObjectThatIsEqualToOthers) (1)    foo => object(Foo) (3)        x => int(5)         y => str(3) "abc"        z => bool(True)
```